### PR TITLE
Make constructor public so that it can be called

### DIFF
--- a/src/main/java/edu/vt/ece/hw4/locks/MCSLock.java
+++ b/src/main/java/edu/vt/ece/hw4/locks/MCSLock.java
@@ -16,7 +16,7 @@ public class MCSLock implements Lock {
     AtomicReference<QNode> queue;
     ThreadLocal<QNode> myNode;
 
-    MCSLock() {
+    public MCSLock() {
         queue = new AtomicReference<>(null);
         // initialize thread-local variable
         myNode = ThreadLocal.withInitial(() -> new QNode());


### PR DESCRIPTION
At least with my version of Java, if that constructor is not explicitly defined as public, it is not possible to create a MCSLock from the Benchmark.java in the upper directory level. This triggers an error like:
```
error: MCSLock() is not public in MCSLock; cannot be accessed from outside package
```
Signed-off-by: Carlos Bilbao <bilbao@vt.edu>